### PR TITLE
Authorization ID must not be deterministic for authorization code flow

### DIFF
--- a/Classes/Authentication/OpenIdConnectToken.php
+++ b/Classes/Authentication/OpenIdConnectToken.php
@@ -2,9 +2,9 @@
 declare(strict_types=1);
 namespace Flownative\OpenIdConnect\Client\Authentication;
 
-use Flownative\OAuth2\Client\OAuthClient;
 use Flownative\OpenIdConnect\Client\ConnectionException;
 use Flownative\OpenIdConnect\Client\IdentityToken;
+use Flownative\OpenIdConnect\Client\OAuthClient;
 use Flownative\OpenIdConnect\Client\OpenIdConnectClient;
 use Flownative\OpenIdConnect\Client\ServiceException;
 use Neos\Flow\Mvc\ActionRequest;
@@ -76,8 +76,9 @@ final class OpenIdConnectToken extends AbstractToken implements SessionlessToken
             $identityToken = $this->extractIdentityTokenFromAuthorizationHeader($this->authorizationHeader);
 
         } elseif (isset($this->queryParameters[self::OIDC_PARAMETER_NAME])) {
-            if (!isset($this->queryParameters[OAuthClient::AUTHORIZATION_ID_QUERY_PARAMETER_NAME])) {
-                throw new AccessDeniedException(sprintf('Missing authorization identifier "%s" from query parameters', OAuthClient::AUTHORIZATION_ID_QUERY_PARAMETER_NAME), 1560350311);
+            $authorizationIdQueryParameterName = OAuthClient::generateAuthorizationIdQueryParameterName(OAuthClient::SERVICE_TYPE);
+            if (!isset($this->queryParameters[$authorizationIdQueryParameterName])) {
+                throw new AccessDeniedException(sprintf('Missing authorization identifier "%s" from query parameters', $authorizationIdQueryParameterName), 1560350311);
             }
             try {
                 $tokenArguments = TokenArguments::fromSignedString($this->queryParameters[self::OIDC_PARAMETER_NAME]);
@@ -86,7 +87,7 @@ final class OpenIdConnectToken extends AbstractToken implements SessionlessToken
                 throw new AccessDeniedException('Could not extract token arguments from query parameters', 1560349658, $exception);
             }
 
-            $authorizationIdentifier = $this->queryParameters[OAuthClient::AUTHORIZATION_ID_QUERY_PARAMETER_NAME];
+            $authorizationIdentifier = $this->queryParameters[$authorizationIdQueryParameterName];
             $client = new OpenIdConnectClient($tokenArguments[TokenArguments::SERVICE_NAME]);
 
             try {

--- a/Classes/OAuthClient.php
+++ b/Classes/OAuthClient.php
@@ -22,6 +22,8 @@ use Neos\Flow\Annotations as Flow;
  */
 class OAuthClient extends \Flownative\OAuth2\Client\OAuthClient
 {
+    public const SERVICE_TYPE= 'oidc';
+
     /**
      * @Flow\InjectConfiguration(path="http.baseUri", package="Neos.Flow")
      * @var string
@@ -105,7 +107,7 @@ class OAuthClient extends \Flownative\OAuth2\Client\OAuthClient
      */
     public function getServiceType(): string
     {
-        return 'oidc';
+        return self::SERVICE_TYPE;
     }
 
     /**

--- a/Classes/OpenIdConnectClient.php
+++ b/Classes/OpenIdConnectClient.php
@@ -144,29 +144,32 @@ final class OpenIdConnectClient
     }
 
     /**
-     * Requests an access token via OAuth, using an OpenID Connect scope
+     * Returns OAuth access token, using an OpenID Connect scope
      *
-     * This method is usually used using the OAuth Client Credentials Flow for machine-to-machine applications.
-     * Therefore the grant type is usually Authorization::GRANT_CLIENT_CREDENTIALS. You need to specify the
+     * This method is used using the OAuth Client Credentials Flow for machine-to-machine applications.
+     * Therefore the grant type must be Authorization::GRANT_CLIENT_CREDENTIALS. You need to specify the
      * client identifier and client secret and may optionally specify a scope.
+     *
+     * This method will check if an access token already exists (stored in an Authorization record), and
+     * if it doesn't, requests one via OAuth. The authorization id which leads to the Authorization record
+     * is deterministic and derived from the service name, client id, client secret and scope.
      *
      * @param string $serviceName The service name used in the OAuth configuration
      * @param string $clientId Client ID
      * @param string $clientSecret Client Secret
      * @param string $scope The authorization scope. Must be identifiers separated by space. "openid" will automatically be requested
-     * @param string $grantType One of the Authorization::GRANT_* constants
      * @param array $additionalParameters Additional parameters to provide in the request body while requesting the token. For example ['audience' => 'https://www.example.com/api/v1']
      * @return AccessToken
      * @throws AuthenticationException
      * @throws ConnectionException
      * @throws IdentityProviderException
      */
-    public function getAccessToken(string $serviceName, string $clientId, string $clientSecret, string $scope, string $grantType, array $additionalParameters = []): AccessToken
+    public function getAccessToken(string $serviceName, string $clientId, string $clientSecret, string $scope, array $additionalParameters = []): AccessToken
     {
         $scope = trim(implode(' ', array_unique(array_merge(explode(' ', $scope), ['openid']))));
 
         $accessToken = null;
-        $authorizationId = Authorization::calculateAuthorizationId($serviceName, $clientId, $scope, $grantType);
+        $authorizationId = Authorization::generateAuthorizationIdForClientCredentialsGrant($serviceName, $clientId, $clientSecret, $scope);
         $authorization = $this->getAuthorization($authorizationId);
 
         if ($authorization !== null) {
@@ -181,7 +184,7 @@ final class OpenIdConnectClient
         if ($accessToken === null || $accessToken->hasExpired()) {
             $this->logger->info(sprintf('OpenID Connect Client: Requesting new access token for service %s using client id %s %s', $serviceName, $clientId, ($scope ? 'requesting scope "' . $scope . '"' : 'requesting no scope')), LogEnvironment::fromMethodName(__METHOD__));
 
-            $this->oAuthClient->requestAccessToken($serviceName, $clientId, $clientSecret, $scope, $grantType, $additionalParameters);
+            $this->oAuthClient->requestAccessToken($serviceName, $clientId, $clientSecret, $scope, $additionalParameters);
             $authorization = $this->getAuthorization($authorizationId);
             if ($authorization === null) {
                 throw new ConnectionException(sprintf('OpenID Connect Client: Failed retrieving access token for service "%s", clientId "%s": No authorization found for id %s', $serviceName, $clientId, $authorizationId));
@@ -223,23 +226,6 @@ final class OpenIdConnectClient
             throw new \RuntimeException(sprintf('OpenID Connect Client: Authorization Code Flow requires "clientId" and "clientSecret" to be configured for service "%s".', $this->serviceName), 1596456168);
         }
         return $this->oAuthClient->startAuthorization($this->options['clientId'], $this->options['clientSecret'], $returnToUri, $scope);
-    }
-
-    /**
-     * Returns the current OAuth token, if any
-     *
-     * @param string $authorizationIdentifier
-     * @return Authorization|null
-     * @throws ConnectionException
-     */
-    public function getAuthorization(string $authorizationIdentifier): ?Authorization
-    {
-        try {
-            $authorization = $this->oAuthClient->getAuthorization($authorizationIdentifier);
-        } catch (ORMException | OptimisticLockException $exception) {
-            throw new ConnectionException(sprintf('OpenID Connect Client: Failed retrieving oAuth token %s: %s', $authorizationIdentifier, $exception->getMessage()), 1559202394);
-        }
-        return $authorization;
     }
 
     /**
@@ -325,5 +311,22 @@ final class OpenIdConnectClient
                 $this->options[self::DISCOVERY_OPTIONS_MAPPING[$optionName]] = $optionValue;
             }
         }
+    }
+
+    /**
+     * Returns the specified authorization
+     *
+     * @param string $authorizationIdentifier
+     * @return Authorization|null
+     * @throws ConnectionException
+     */
+    private function getAuthorization(string $authorizationIdentifier): ?Authorization
+    {
+        try {
+            $authorization = $this->oAuthClient->getAuthorization($authorizationIdentifier);
+        } catch (ORMException | OptimisticLockException $exception) {
+            throw new ConnectionException(sprintf('OpenID Connect Client: Failed retrieving oAuth token %s: %s', $authorizationIdentifier, $exception->getMessage()), 1559202394);
+        }
+        return $authorization;
     }
 }

--- a/Classes/OpenIdConnectClient.php
+++ b/Classes/OpenIdConnectClient.php
@@ -250,7 +250,11 @@ final class OpenIdConnectClient
         if (!isset($tokenValues['id_token'])) {
             throw new ServiceException('OpenID Connect Client: No id_token found in values of current oAuth token', 1559208674);
         }
-        return IdentityToken::fromJwt($tokenValues['id_token']);
+        try {
+            return IdentityToken::fromJwt($tokenValues['id_token']);
+        } catch (\JsonException $e) {
+            throw new ServiceException('OpenID Connect Client: Failed parsing identity token from JWT', 1602501992, $e);
+        }
     }
 
     /**

--- a/Tests/Unit/IdentityTokenTest.php
+++ b/Tests/Unit/IdentityTokenTest.php
@@ -11,6 +11,7 @@ namespace Flownative\OpenIdConnect\Client;
  * source code.
  */
 
+use JsonException;
 use PHPUnit\Framework\TestCase;
 
 class IdentityTokenTest extends TestCase
@@ -35,6 +36,7 @@ class IdentityTokenTest extends TestCase
      * @test
      * @dataProvider invalidJsonStrings
      * @param $json
+     * @throws JsonException
      */
     public function fromJsonRejectsInvalidJsonStrings(string $json, int $expectedExceptionCode): void
     {
@@ -49,6 +51,7 @@ class IdentityTokenTest extends TestCase
      * … (binary data of signature) …
      *
      * @test
+     * @throws JsonException
      */
     public function fromJsonSetsValuesCorrectly(): void
     {
@@ -62,6 +65,7 @@ class IdentityTokenTest extends TestCase
 
     /**
      * @test
+     * @throws JsonException
      */
     public function asJwtReturnsTokenAsString(): void
     {


### PR DESCRIPTION
This change adjusts the OIDC client package to the backwards-incompatible change in https://github.com/flownative/flow-oauth2-client/issues/13