### PR TITLE
TASK: Use LoggerInterface instead of PsrSystemLoggerInterface

### DIFF
--- a/Classes/Authentication/OpenIdConnectProvider.php
+++ b/Classes/Authentication/OpenIdConnectProvider.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+
 namespace Flownative\OpenIdConnect\Client\Authentication;
 
 use Flownative\OpenIdConnect\Client\AuthenticationException;
@@ -8,7 +9,6 @@ use Flownative\OpenIdConnect\Client\IdentityToken;
 use Flownative\OpenIdConnect\Client\OpenIdConnectClient;
 use Flownative\OpenIdConnect\Client\ServiceException;
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Log\PsrSystemLoggerInterface;
 use Neos\Flow\Log\Utility\LogEnvironment;
 use Neos\Flow\Security\Account;
 use Neos\Flow\Security\AccountRepository;
@@ -22,6 +22,7 @@ use Neos\Flow\Security\Exception\UnsupportedAuthenticationTokenException;
 use Neos\Flow\Security\Policy\PolicyService;
 use Neos\Flow\Security\Policy\Role;
 use Neos\Cache\Exception as CacheException;
+use Psr\Log\LoggerInterface;
 
 final class OpenIdConnectProvider extends AbstractProvider
 {
@@ -39,7 +40,7 @@ final class OpenIdConnectProvider extends AbstractProvider
 
     /**
      * @Flow\Inject
-     * @var PsrSystemLoggerInterface
+     * @var LoggerInterface
      */
     protected $logger;
 

--- a/Classes/Authentication/TokenArguments.php
+++ b/Classes/Authentication/TokenArguments.php
@@ -3,9 +3,9 @@ declare(strict_types = 1);
 namespace Flownative\OpenIdConnect\Client\Authentication;
 
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Log\PsrSystemLoggerInterface;
 use Neos\Flow\Security\Cryptography\HashService;
 use Neos\Flow\Security\Exception\InvalidHashException;
+use Psr\Log\LoggerInterface;
 
 final class TokenArguments implements \ArrayAccess
 {
@@ -20,7 +20,7 @@ final class TokenArguments implements \ArrayAccess
 
     /**
      * @Flow\Inject
-     * @var PsrSystemLoggerInterface
+     * @var LoggerInterface
      */
     protected $logger;
 


### PR DESCRIPTION
Which is removed with Flow 7.0