### PR TITLE
Compatibility with Flow 7.x

### DIFF
--- a/Classes/Http/SetJwtCookieMiddleware.php
+++ b/Classes/Http/SetJwtCookieMiddleware.php
@@ -5,14 +5,16 @@ namespace Flownative\OpenIdConnect\Client\Http;
 use Flownative\OpenIdConnect\Client\Authentication\OpenIdConnectToken;
 use Flownative\OpenIdConnect\Client\IdentityToken;
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Http\Component\ComponentContext;
-use Neos\Flow\Http\Component\ComponentInterface;
 use Neos\Flow\Http\Cookie;
 use Neos\Flow\Log\Utility\LogEnvironment;
 use Neos\Flow\Security\Context as SecurityContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Log\LoggerInterface;
 
-final class SetJwtCookieComponent implements ComponentInterface
+final class SetJwtCookieMiddleware implements MiddlewareInterface
 {
     /**
      * @Flow\Inject
@@ -27,22 +29,15 @@ final class SetJwtCookieComponent implements ComponentInterface
     protected $logger;
 
     /**
+     * @Flow\InjectConfiguration(path="middleware")
      * @var array
      */
-    private $options;
+    protected $options;
 
     /**
-     * @param array|null $options
+     * @return void
      */
-    public function __construct(array $options = null)
-    {
-        $this->options = $options;
-    }
-
-    /**
-     *
-     */
-    public function initializeObject()
+    public function initializeObject(): void
     {
         if (isset($this->options['cookieName'])) {
             $this->logger->warning('OpenID Connect: Option "cookieName" was used - please use "cookie.name" instead.', LogEnvironment::fromMethodName(__METHOD__));
@@ -55,31 +50,34 @@ final class SetJwtCookieComponent implements ComponentInterface
     }
 
     /**
-     * @param ComponentContext $componentContext
+     * @param ServerRequestInterface $request
+     * @param RequestHandlerInterface $handler
+     * @return ResponseInterface
      */
-    public function handle(ComponentContext $componentContext): void
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
+        $response = $handler->handle($request);
+
         if (!$this->securityContext->isInitialized() && !$this->securityContext->canBeInitialized()) {
             $this->logger->debug('OpenID Connect: Cannot send JWT cookie because the security context could not be initialized.', LogEnvironment::fromMethodName(__METHOD__));
-            return;
+            return $response;
         }
         if (!$this->isOpenIdConnectAuthentication()) {
-            return;
+            return $response;
         }
         $account = $this->securityContext->getAccountByAuthenticationProviderName($this->options['authenticationProviderName']);
         if ($account === null) {
             $this->logger->debug(sprintf('OpenID Connect: No account is authenticated using the provider %s, removing JWT cookie "%s" if it exists.', $this->options['authenticationProviderName'], $this->options['cookie']['name']), LogEnvironment::fromMethodName(__METHOD__));
-            $this->removeJwtCookie($componentContext);
-            return;
+            return $this->removeJwtCookie($response);
         }
 
         $identityToken = $account->getCredentialsSource();
         if (!$identityToken instanceof IdentityToken) {
             $this->logger->error(sprintf('OpenID Connect: No identity token found in credentials source of account %s - could not set JWT cookie.', $account->getAccountIdentifier()), LogEnvironment::fromMethodName(__METHOD__));
-            return;
+            return $response;
         }
 
-        $this->setJwtCookie($componentContext, $identityToken->asJwt());
+        return $this->setJwtCookie($response, $identityToken->asJwt());
     }
 
     /**
@@ -96,21 +94,23 @@ final class SetJwtCookieComponent implements ComponentInterface
     }
 
     /**
-     * @param ComponentContext $componentContext
+     * @param ResponseInterface $response
      * @param string $jwt
+     * @return ResponseInterface
      */
-    private function setJwtCookie(ComponentContext $componentContext, string $jwt): void
+    private function setJwtCookie(ResponseInterface $response, string $jwt): ResponseInterface
     {
         $jwtCookie = new Cookie($this->options['cookie']['name'], $jwt, 0, null, null, '/', $this->options['cookie']['secure'], false, $this->options['cookie']['sameSite']);
-        $componentContext->replaceHttpResponse($componentContext->getHttpResponse()->withAddedHeader('Set-Cookie', (string)$jwtCookie));
+        return $response->withAddedHeader('Set-Cookie', (string)$jwtCookie);
     }
 
     /**
-     * @param ComponentContext $componentContext
+     * @param ResponseInterface $response
+     * @return ResponseInterface
      */
-    private function removeJwtCookie(ComponentContext $componentContext): void
+    private function removeJwtCookie(ResponseInterface $response): ResponseInterface
     {
         $emptyJwtCookie = new Cookie($this->options['cookie']['name'], '', 1, null, null, '/', $this->options['cookie']['secure'], false, $this->options['cookie']['sameSite']);
-        $componentContext->replaceHttpResponse($componentContext->getHttpResponse()->withAddedHeader('Set-Cookie', (string)$emptyJwtCookie));
+        return $response->withAddedHeader('Set-Cookie', (string)$emptyJwtCookie);
     }
 }

--- a/Configuration/Settings.Http.yaml
+++ b/Configuration/Settings.Http.yaml
@@ -1,15 +1,17 @@
 Neos:
   Flow:
     http:
-      chain:
-        'postprocess':
-          chain:
-            'Flownative.OpenIdConnect.Client:setJwtCookie':
-              'position': 'after setSessionCookie'
-              component: 'Flownative\OpenIdConnect\Client\Http\SetJwtCookieComponent'
-              componentOptions:
-                authenticationProviderName: 'Flownative.OpenIdConnect.Client:OidcProvider'
-                cookie:
-                  name: 'flownative_oidc_jwt'
-                  secure: true
-                  sameSite: 'strict'
+      middlewares:
+        'Flownative.OpenIdConnect.Client:setJwtCookie':
+          'position': 'after session'
+          middleware: 'Flownative\OpenIdConnect\Client\Http\SetJwtCookieMiddleware'
+
+Flownative:
+  OpenIdConnect:
+    Client:
+      middleware:
+        authenticationProviderName: 'Flownative.OpenIdConnect.Client:OidcProvider'
+        cookie:
+          name: 'flownative_oidc_jwt'
+          secure: true
+          sameSite: 'strict'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -8,16 +8,14 @@ Flownative:
 #            clientId: '@!EDD5.370D.8247.FED9!0001!B1C9.92C1!1008!13DB.54D8.65DE.2761'
 #            clientSecret: 'very-secret'
 
+#      middleware:
+#        cookie:
+#          name: 'your_own_cookie_name'
+#          secure: true
+#          sameSite: 'strict'
+
 #Neos:
 #  Flow:
-#    http:
-#      chain:
-#        'postprocess':
-#          chain:
-#            'Flownative.OpenIdConnect.Client:setJwtCookie':
-#              componentOptions:
-#                cookieName: 'your-own-cookie-name-jwt'
-
 #    security:
 #      authentication:
 #        providers:

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
         }
     ],
     "require": {
-        "neos/flow": "~6.0",
+        "neos/flow": "^6.0 || ^7.0",
         "guzzlehttp/guzzle": "^6.3",
-        "flownative/oauth2-client": "^2.0",
+        "flownative/oauth2-client": "^2.0 || dev-flow-7-compatibility",
         "phpseclib/phpseclib": "^2.0",
         "lcobucci/jwt": "^3.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "neos/flow": "^6.0 || ^7.0",
         "guzzlehttp/guzzle": "^6.3",
-        "flownative/oauth2-client": "^2.0 || dev-flow-7-compatibility",
+        "flownative/oauth2-client": "^3.0",
         "phpseclib/phpseclib": "^2.0",
         "lcobucci/jwt": "^3.3"
     },


### PR DESCRIPTION
This change provides compatibility with Flow 7.x. It contains breaking changes regarding the settings, as the HTTP component was replaced by a middleware, which doesn't support the same way of providing options.

See the updated README for configuration changes.