### PR TITLE
BUGFIX: Do not send an empty JWT on every request

### DIFF
--- a/Classes/Http/SetJwtCookieMiddleware.php
+++ b/Classes/Http/SetJwtCookieMiddleware.php
@@ -65,10 +65,14 @@ final class SetJwtCookieMiddleware implements MiddlewareInterface
         if (!$this->isOpenIdConnectAuthentication()) {
             return $response;
         }
+
         $account = $this->securityContext->getAccountByAuthenticationProviderName($this->options['authenticationProviderName']);
         if ($account === null) {
             $this->logger->debug(sprintf('OpenID Connect: No account is authenticated using the provider %s, removing JWT cookie "%s" if it exists.', $this->options['authenticationProviderName'], $this->options['cookie']['name']), LogEnvironment::fromMethodName(__METHOD__));
-            return $this->removeJwtCookie($response);
+            if (isset($request->getCookieParams()[$this->options['cookie']['name']])) {
+                    return $this->removeJwtCookie($response);
+            }
+            return $response;
         }
 
         $identityToken = $account->getCredentialsSource();


### PR DESCRIPTION
This checks the presence of an JWT cookie in the request
and only sends an empty cookie, if a cookie with that name
is present.

resolves: #20