### PR TITLE
Allow setting JwtCookie httpOnly flag via settings

### DIFF
--- a/Classes/Http/SetJwtCookieMiddleware.php
+++ b/Classes/Http/SetJwtCookieMiddleware.php
@@ -104,7 +104,7 @@ final class SetJwtCookieMiddleware implements MiddlewareInterface
      */
     private function setJwtCookie(ResponseInterface $response, string $jwt): ResponseInterface
     {
-        $jwtCookie = new Cookie($this->options['cookie']['name'], $jwt, 0, null, null, '/', $this->options['cookie']['secure'], false, $this->options['cookie']['sameSite']);
+        $jwtCookie = new Cookie($this->options['cookie']['name'], $jwt, 0, null, null, '/', $this->options['cookie']['secure'], $this->options['cookie']['httpOnly'], $this->options['cookie']['sameSite']);
         return $response->withAddedHeader('Set-Cookie', (string)$jwtCookie);
     }
 
@@ -114,7 +114,7 @@ final class SetJwtCookieMiddleware implements MiddlewareInterface
      */
     private function removeJwtCookie(ResponseInterface $response): ResponseInterface
     {
-        $emptyJwtCookie = new Cookie($this->options['cookie']['name'], '', 1, null, null, '/', $this->options['cookie']['secure'], false, $this->options['cookie']['sameSite']);
+        $emptyJwtCookie = new Cookie($this->options['cookie']['name'], '', 1, null, null, '/', $this->options['cookie']['secure'], $this->options['cookie']['httpOnly'], $this->options['cookie']['sameSite']);
         return $response->withAddedHeader('Set-Cookie', (string)$emptyJwtCookie);
     }
 }

--- a/Configuration/Settings.Http.yaml
+++ b/Configuration/Settings.Http.yaml
@@ -15,3 +15,4 @@ Flownative:
           name: 'flownative_oidc_jwt'
           secure: true
           sameSite: 'strict'
+          httpOnly: false

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -13,6 +13,7 @@ Flownative:
 #          name: 'your_own_cookie_name'
 #          secure: true
 #          sameSite: 'strict'
+#          httpOnly: true
 
 #Neos:
 #  Flow:


### PR DESCRIPTION
I'd suggest allowing to set the JwtCookie's httponly flag in [SetJwtCookieMiddleware.php](https://github.com/flownative/flow-openidconnect-client/blob/master/Classes/Http/SetJwtCookieMiddleware.php) to true for additional security. 

I'm fairly new to the cookie game, so please correct me if I'm wrong.