### PR TITLE
BUGFIX: Fix support for multiple services in one installation

### DIFF
--- a/Classes/Http/SetJwtCookieMiddleware.php
+++ b/Classes/Http/SetJwtCookieMiddleware.php
@@ -29,10 +29,20 @@ final class SetJwtCookieMiddleware implements MiddlewareInterface
     protected $logger;
 
     /**
-     * @Flow\InjectConfiguration(path="middleware")
      * @var array
      */
-    protected $options;
+    private $options;
+
+    /**
+     * @var array
+     */
+    private $authenticationProviderConfiguration;
+
+    public function __construct(array $options, array $authenticationProviderConfiguration)
+    {
+        $this->options = $options;
+        $this->authenticationProviderConfiguration = $authenticationProviderConfiguration;
+    }
 
     /**
      * @return void
@@ -62,59 +72,55 @@ final class SetJwtCookieMiddleware implements MiddlewareInterface
             $this->logger->debug('OpenID Connect: Cannot send JWT cookie because the security context could not be initialized.', LogEnvironment::fromMethodName(__METHOD__));
             return $response;
         }
-        if (!$this->isOpenIdConnectAuthentication()) {
-            return $response;
-        }
-
-        $account = $this->securityContext->getAccountByAuthenticationProviderName($this->options['authenticationProviderName']);
-        if ($account === null) {
-            if (isset($request->getCookieParams()[$this->options['cookie']['name']])) {
-                $this->logger->debug(sprintf('OpenID Connect: No account is authenticated using the provider %s, removing JWT cookie "%s".', $this->options['authenticationProviderName'], $this->options['cookie']['name']), LogEnvironment::fromMethodName(__METHOD__));
-                return $this->removeJwtCookie($response);
-            }
-            return $response;
-        }
-
-        $identityToken = $account->getCredentialsSource();
-        if (!$identityToken instanceof IdentityToken) {
-            $this->logger->error(sprintf('OpenID Connect: No identity token found in credentials source of account %s - could not set JWT cookie.', $account->getAccountIdentifier()), LogEnvironment::fromMethodName(__METHOD__));
-            return $response;
-        }
-
-        return $this->setJwtCookie($response, $identityToken->asJwt());
-    }
-
-    /**
-     * @return bool
-     */
-    private function isOpenIdConnectAuthentication(): bool
-    {
         foreach ($this->securityContext->getAuthenticationTokensOfType(OpenIdConnectToken::class) as $token) {
-            if ($token->getAuthenticationProviderName() === $this->options['authenticationProviderName']) {
-                return true;
+            $providerName = $token->getAuthenticationProviderName();
+            $providerOptions = $this->authenticationProviderConfiguration[$token->getAuthenticationProviderName()]['providerOptions'] ?? [];
+            $account = $this->securityContext->getAccountByAuthenticationProviderName($providerName);
+            $cookieName = $providerOptions['jwtCookieName'] ?? $this->options['cookie']['name'] ?? 'flownative_oidc_jwt';
+            $cookieSecure = $this->options['cookie']['secure'] ?? true;
+            $cookieSameSite = $this->options['cookie']['sameSite'] ?? 'strict';
+            if ($account === null) {
+                if (isset($request->getCookieParams()[$cookieName])) {
+                    $this->logger->debug(sprintf('OpenID Connect: No account is authenticated using the provider %s, removing JWT cookie "%s".', $providerName, $cookieName), LogEnvironment::fromMethodName(__METHOD__));
+                    $response = $this->removeJwtCookie($response, $cookieName, $cookieSecure, $cookieSameSite);
+                }
+                continue;
             }
+            $identityToken = $account->getCredentialsSource();
+            if (!$identityToken instanceof IdentityToken) {
+                $this->logger->error(sprintf('OpenID Connect: No identity token found in credentials source of account %s - could not set JWT cookie.', $account->getAccountIdentifier()), LogEnvironment::fromMethodName(__METHOD__));
+                continue;
+            }
+
+            $response = $this->setJwtCookie($response, $cookieName, $cookieSecure, $cookieSameSite, $identityToken->asJwt());
         }
-        return false;
+        return $response;
     }
 
     /**
      * @param ResponseInterface $response
+     * @param string $cookieName
+     * @param bool $secure
+     * @param string $sameSite
      * @param string $jwt
      * @return ResponseInterface
      */
-    private function setJwtCookie(ResponseInterface $response, string $jwt): ResponseInterface
+    private function setJwtCookie(ResponseInterface $response, string $cookieName, bool $secure, string $sameSite, string $jwt): ResponseInterface
     {
-        $jwtCookie = new Cookie($this->options['cookie']['name'], $jwt, 0, null, null, '/', $this->options['cookie']['secure'], false, $this->options['cookie']['sameSite']);
+        $jwtCookie = new Cookie($cookieName, $jwt, 0, null, null, '/', $secure, false, $sameSite);
         return $response->withAddedHeader('Set-Cookie', (string)$jwtCookie);
     }
 
     /**
      * @param ResponseInterface $response
+     * @param string $cookieName
+     * @param bool $secure
+     * @param string $sameSite
      * @return ResponseInterface
      */
-    private function removeJwtCookie(ResponseInterface $response): ResponseInterface
+    private function removeJwtCookie(ResponseInterface $response, string $cookieName, bool $secure, string $sameSite): ResponseInterface
     {
-        $emptyJwtCookie = new Cookie($this->options['cookie']['name'], '', 1, null, null, '/', $this->options['cookie']['secure'], false, $this->options['cookie']['sameSite']);
+        $emptyJwtCookie = new Cookie($cookieName, '', 1, null, null, '/', $secure, false, $sameSite);
         return $response->withAddedHeader('Set-Cookie', (string)$emptyJwtCookie);
     }
 }

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -24,3 +24,10 @@ Flownative\OpenIdConnect\Client\OAuthClient:
         arguments:
           1:
             value: Flownative_OAuth2_Client_State
+
+Flownative\OpenIdConnect\Client\Http\SetJwtCookieMiddleware:
+  arguments:
+    1:
+      setting: 'Flownative.OpenIdConnect.Client.middleware'
+    2:
+      setting: 'Neos.Flow.security.authentication.providers'

--- a/Configuration/Settings.Http.yaml
+++ b/Configuration/Settings.Http.yaml
@@ -3,15 +3,5 @@ Neos:
     http:
       middlewares:
         'Flownative.OpenIdConnect.Client:setJwtCookie':
-          'position': 'after session'
+          position: 'after session'
           middleware: 'Flownative\OpenIdConnect\Client\Http\SetJwtCookieMiddleware'
-
-Flownative:
-  OpenIdConnect:
-    Client:
-      middleware:
-        authenticationProviderName: 'Flownative.OpenIdConnect.Client:OidcProvider'
-        cookie:
-          name: 'flownative_oidc_jwt'
-          secure: true
-          sameSite: 'strict'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -8,12 +8,6 @@ Flownative:
 #            clientId: '@!EDD5.370D.8247.FED9!0001!B1C9.92C1!1008!13DB.54D8.65DE.2761'
 #            clientSecret: 'very-secret'
 
-#      middleware:
-#        cookie:
-#          name: 'your_own_cookie_name'
-#          secure: true
-#          sameSite: 'strict'
-
 #Neos:
 #  Flow:
 #    security:


### PR DESCRIPTION
Extends the `SetJwtCookieMiddleware` so that it uses the configured
cookie options from the corresponding authentication provider.

Fixes: #29