### PR TITLE
BUGFIX: Fix support for JWTs without 'kid' header

### DIFF
--- a/Classes/IdentityToken.php
+++ b/Classes/IdentityToken.php
@@ -190,14 +190,14 @@ class IdentityToken
      *
      * @param array $keys
      * @param string $algorithm
-     * @param string $keyIdentifier
+     * @param string|null $keyIdentifier
      * @return array
      * @throws ServiceException
      */
-    private function getMatchingKeyForJws(array $keys, string $algorithm, string $keyIdentifier): array {
+    private function getMatchingKeyForJws(array $keys, string $algorithm, ?string $keyIdentifier): array {
         foreach ($keys as $key) {
             if ($key['kty'] === 'RSA') {
-                if (!isset($header['kid']) || $key['kid'] === $keyIdentifier) {
+                if ($keyIdentifier !== null || $key['kid'] === $keyIdentifier) {
                     return $key;
                 }
             } else if (isset($key['alg']) && $key['alg'] === $algorithm && $key['kid'] === $keyIdentifier) {


### PR DESCRIPTION
In `IdentityToken::hasValidSignature()` the method `getMatchingKeyForJws()` can be invoked with a `$keyIdentifier`
parameter of `null`. But the signature and implementation didn't support that case.