### PR TITLE
FEATURE: Configurable httpOnly JWT cookie

### DIFF
--- a/Classes/Http/SetJwtCookieMiddleware.php
+++ b/Classes/Http/SetJwtCookieMiddleware.php
@@ -78,11 +78,12 @@ final class SetJwtCookieMiddleware implements MiddlewareInterface
             $account = $this->securityContext->getAccountByAuthenticationProviderName($providerName);
             $cookieName = $providerOptions['jwtCookieName'] ?? $this->options['cookie']['name'] ?? 'flownative_oidc_jwt';
             $cookieSecure = $this->options['cookie']['secure'] ?? true;
+            $cookieHttpOnly = $this->options['cookie']['httpOnly'] ?? false;
             $cookieSameSite = $this->options['cookie']['sameSite'] ?? 'strict';
             if ($account === null) {
                 if (isset($request->getCookieParams()[$cookieName])) {
                     $this->logger->debug(sprintf('OpenID Connect: No account is authenticated using the provider %s, removing JWT cookie "%s".', $providerName, $cookieName), LogEnvironment::fromMethodName(__METHOD__));
-                    $response = $this->removeJwtCookie($response, $cookieName, $cookieSecure, $cookieSameSite);
+                    $response = $this->removeJwtCookie($response, $cookieName, $cookieSecure, $cookieHttpOnly, $cookieSameSite);
                 }
                 continue;
             }
@@ -92,7 +93,7 @@ final class SetJwtCookieMiddleware implements MiddlewareInterface
                 continue;
             }
 
-            $response = $this->setJwtCookie($response, $cookieName, $cookieSecure, $cookieSameSite, $identityToken->asJwt());
+            $response = $this->setJwtCookie($response, $cookieName, $cookieSecure, $cookieHttpOnly, $cookieSameSite, $identityToken->asJwt());
         }
         return $response;
     }
@@ -101,13 +102,14 @@ final class SetJwtCookieMiddleware implements MiddlewareInterface
      * @param ResponseInterface $response
      * @param string $cookieName
      * @param bool $secure
+     * @param bool $httpOnly
      * @param string $sameSite
      * @param string $jwt
      * @return ResponseInterface
      */
-    private function setJwtCookie(ResponseInterface $response, string $cookieName, bool $secure, string $sameSite, string $jwt): ResponseInterface
+    private function setJwtCookie(ResponseInterface $response, string $cookieName, bool $secure, bool $httpOnly, string $sameSite, string $jwt): ResponseInterface
     {
-        $jwtCookie = new Cookie($cookieName, $jwt, 0, null, null, '/', $secure, false, $sameSite);
+        $jwtCookie = new Cookie($cookieName, $jwt, 0, null, null, '/', $secure, $httpOnly, $sameSite);
         return $response->withAddedHeader('Set-Cookie', (string)$jwtCookie);
     }
 
@@ -115,12 +117,13 @@ final class SetJwtCookieMiddleware implements MiddlewareInterface
      * @param ResponseInterface $response
      * @param string $cookieName
      * @param bool $secure
+     * @param bool $httpOnly
      * @param string $sameSite
      * @return ResponseInterface
      */
-    private function removeJwtCookie(ResponseInterface $response, string $cookieName, bool $secure, string $sameSite): ResponseInterface
+    private function removeJwtCookie(ResponseInterface $response, string $cookieName, bool $secure, bool $httpOnly, string $sameSite): ResponseInterface
     {
-        $emptyJwtCookie = new Cookie($cookieName, '', 1, null, null, '/', $secure, false, $sameSite);
+        $emptyJwtCookie = new Cookie($cookieName, '', 1, null, null, '/', $secure, $httpOnly, $sameSite);
         return $response->withAddedHeader('Set-Cookie', (string)$emptyJwtCookie);
     }
 }

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -4,6 +4,7 @@ Flownative:
       middleware:
         cookie:
           secure: true
+          httpOnly: false
       services: []
 #        exampleService:
 #          options:

--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ Flownative:
         cookie:      
           # For testing purposes allow cookies without HTTPS:
           secure: false
+          # Create an HTTP only cookie for increased security
+          httpOnly: true
 
 Neos:
   Flow:


### PR DESCRIPTION
Adds an option `cookie.httpOnly` that allows to configure the middleware
such that it only creates "HTTP Only" cookies for increased security.

For backwards compatibility reasons the flag is _not_ set by default.

Credits to @florianklueckmann for the initial version

Resolves: #34