### PR TITLE
Don't inject PolicyService lazily

### DIFF
--- a/Classes/Authentication/OpenIdConnectProvider.php
+++ b/Classes/Authentication/OpenIdConnectProvider.php
@@ -26,13 +26,13 @@ use Neos\Cache\Exception as CacheException;
 final class OpenIdConnectProvider extends AbstractProvider
 {
     /**
-     * @Flow\Inject
+     * @Flow\Inject(lazy = false)
      * @var Context
      */
     protected $securityContext;
 
     /**
-     * @Flow\Inject
+     * @Flow\Inject(lazy = false)
      * @var PolicyService
      */
     protected $policyService;


### PR DESCRIPTION
Using a lazy-injected PolicyService at this stage may end up in missing
dependencies in the PolicyService itself.

Resolves #36