### PR TITLE
Allow guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "neos/flow": "^6.0 || ^7.0",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "flownative/oauth2-client": "^4.0.0",
         "phpseclib/phpseclib": "^2.0.31",
         "lcobucci/jwt": "^4.1",


### PR DESCRIPTION
Taking over version constraints on `guzzlehttp/guzzle` from [thephpleague/oauth2-client](https://github.com/thephpleague/oauth2-client/pull/847).

Fixes https://github.com/flownative/flow-openidconnect-client/issues/41