### PR TITLE
Log OIDC messages to security log

### DIFF
--- a/Classes/Authentication/OpenIdConnectEntryPoint.php
+++ b/Classes/Authentication/OpenIdConnectEntryPoint.php
@@ -17,7 +17,7 @@ use Psr\Log\LoggerInterface;
 final class OpenIdConnectEntryPoint extends AbstractEntryPoint
 {
     /**
-     * @Flow\Inject
+     * @Flow\Inject(name="Neos.Flow:SecurityLogger")
      * @var LoggerInterface
      */
     protected $logger;

--- a/Classes/Authentication/OpenIdConnectProvider.php
+++ b/Classes/Authentication/OpenIdConnectProvider.php
@@ -39,7 +39,7 @@ final class OpenIdConnectProvider extends AbstractProvider
     protected $policyService;
 
     /**
-     * @Flow\Inject
+     * @Flow\Inject(name="Neos.Flow:SecurityLogger")
      * @var LoggerInterface
      */
     protected $logger;

--- a/Classes/OpenIdConnectClient.php
+++ b/Classes/OpenIdConnectClient.php
@@ -55,7 +55,7 @@ final class OpenIdConnectClient
     protected $httpClient;
 
     /**
-     * @Flow\Inject
+     * @Flow\Inject(name="Neos.Flow:SecurityLogger")
      * @var LoggerInterface
      */
     protected $logger;


### PR DESCRIPTION
All log messages of this package are now logged to Flow's security log (`Security.log`) instead of using the standard system log (`System.log`).

Resolves #47