### PR TITLE
Fix AuthenticationRequiredException if Basic-Auth is used

### DIFF
--- a/Classes/Authentication/OpenIdConnectToken.php
+++ b/Classes/Authentication/OpenIdConnectToken.php
@@ -72,7 +72,7 @@ final class OpenIdConnectToken extends AbstractToken implements SessionlessToken
      */
     public function extractIdentityTokenFromRequest(string $cookieName): IdentityToken
     {
-        if ($this->authorizationHeader !== null) {
+        if ($this->authorizationHeader !== null && str_contains($this->authorizationHeader, 'Bearer ')) {
             $identityToken = $this->extractIdentityTokenFromAuthorizationHeader($this->authorizationHeader);
 
         } elseif (isset($this->queryParameters[self::OIDC_PARAMETER_NAME])) {


### PR DESCRIPTION
If your neos uses a Basic Auth (for example your staging instance of neos) this leads to a  `AuthenticationRequiredException Could not extract access token from Authorization header: "Bearer" keyword is missing` exception.  
We changed the source code to prevent the extraction of the identity token from the authorization header if it does not contain a bearer token. 

@robertlemke 