### PR TITLE
Replace call to deprecated method forUnsecuredSigner()

### DIFF
--- a/Classes/IdentityToken.php
+++ b/Classes/IdentityToken.php
@@ -2,7 +2,7 @@
 namespace Flownative\OpenIdConnect\Client;
 
 use JsonException;
-use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Encoding\JoseEncoder;
 use Lcobucci\JWT\Token;
 use phpseclib3\Crypt\PublicKeyLoader;
 use phpseclib3\Crypt\RSA;
@@ -97,11 +97,10 @@ class IdentityToken
             throw new \InvalidArgumentException('Failed decoding identity token from JWT.', 1559208043);
         }
 
-        // We don't use the JWT library for signing, so we don't need a full-blown configuration with secrets
-        $jwtConfiguration = Configuration::forUnsecuredSigner();
+        $jwtParser = new Token\Parser(new JoseEncoder());
 
         $identityToken->values = $identityTokenArray;
-        $identityToken->parsedJwt = $jwtConfiguration->parser()->parse($jwt);
+        $identityToken->parsedJwt = $jwtParser->parse($jwt);
         return $identityToken;
     }
 
@@ -134,7 +133,7 @@ class IdentityToken
                     $this->payload,
                     $this->signature
                 );
-            break;
+                break;
             default:
                 throw new ServiceException(sprintf('Unsupported JWT signature type %s.', $this->header['alg']), 1559213623);
         }

--- a/Tests/Unit/IdentityTokenTest.php
+++ b/Tests/Unit/IdentityTokenTest.php
@@ -16,9 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 class IdentityTokenTest extends TestCase
 {
-    /**
-     * @return array
-     */
     public function invalidJsonStrings(): array
     {
         return [
@@ -35,8 +32,7 @@ class IdentityTokenTest extends TestCase
     /**
      * @test
      * @dataProvider invalidJsonStrings
-     * @param $json
-     * @throws JsonException
+     * @throws
      */
     public function fromJsonRejectsInvalidJsonStrings(string $json, int $expectedExceptionCode): void
     {
@@ -51,7 +47,7 @@ class IdentityTokenTest extends TestCase
      * … (binary data of signature) …
      *
      * @test
-     * @throws JsonException
+     * @throws
      */
     public function fromJsonSetsValuesCorrectly(): void
     {
@@ -65,7 +61,7 @@ class IdentityTokenTest extends TestCase
 
     /**
      * @test
-     * @throws JsonException
+     * @throws
      */
     public function asJwtReturnsTokenAsString(): void
     {
@@ -73,5 +69,18 @@ class IdentityTokenTest extends TestCase
         $identityToken = IdentityToken::fromJwt($json);
         $this->assertSame($identityToken->asJwt(), $json);
         $this->assertSame((string)$identityToken, $json);
+    }
+
+    /**
+     * @test
+     */
+    public function isExpiredAtReturnsCorrectResult(): void
+    {
+        $json = 'eyJraWQiOiJkZmViZTVlNy00MjMyLTQ0NjQtOGYyZS0xNTE2ODFhMGQxNzMiLCJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwczovL2lkLmV4YW1wbGUuY29tIiwiYXVkIjoiQCFEREQ1LjM3MEQuODU0Ny5GRkQ5ITAwMDEhQTFDOS45MkMxITAwMDghMTNEQi41NEQ4LjY1REUuMjc2MSIsImV4cCI6MTU1OTIwNTU2MCwiaWF0IjoxNTU5MjAxOTYwLCJhdXRoX3RpbWUiOjE1NTkyMDE5NTksImF0X2hhc2giOiJfU1BHdHM1OUlTbFdNSHhzMmEwM3N3Iiwib3hPcGVuSURDb25uZWN0VmVyc2lvbiI6Im9wZW5pZGNvbm5lY3QtMS4wIiwic3ViIjoiVVdBWWZ6em1jYU5BWnlfQzhhOFVvVXhNbWhUMUlsY0tsWEc4VG5Xa3lJTSJ9.VsOdosHuRWVaoacWG1CNJl0IZrHH-HbFTCZDcQDtFPSma13sHO-C69tm_HTjHX5DnMX6B_lDCgu3A8AsSZIQEG71z_Mnd2uxHoUrKUtHr8iM9bhpPKMnaXx9jr0O1EtKAJDLkz4qdzNunyOU7Ud94Lc8YxIjf7FZH_-jJc0UqFyFKY2rdEiZQVATNG94F-SIWA4CK5FZtW47TCL8EPBUzP8gGG8g6eMBEIfv80uWQxpJ59_UB91D8U6zSOiA4JrFDBRLkIX2kGnUZ7eu1G-4O6TglL_Id0oMeJdNEsMARYKHGmYZjvHGFVoLyoxca1KDK5dlcnLsYyxfKsZWNrTaqA';
+        $identityToken = IdentityToken::fromJwt($json);
+
+        # Token expired at 2019-05-30 08:39:20.000000
+        $this->assertFalse($identityToken->isExpiredAt(\DateTimeImmutable::createFromFormat('d.m.Y H:i:s', '29.05.2019 09:00:00')));
+        $this->assertTrue($identityToken->isExpiredAt(\DateTimeImmutable::createFromFormat('d.m.Y H:i:s', '31.05.2019 09:00:00')));
     }
 }


### PR DESCRIPTION
The method Lcobucci\JWT\Configuration::forUnsecuredSigner() was deprecated, therefore IdentityToken now uses an alternative way of parsing the JWT.

Resolves #53