### PR TITLE
TASK: Transfer the access token from the OIDC response 

### DIFF
--- a/Classes/Authentication/OpenIdConnectProvider.php
+++ b/Classes/Authentication/OpenIdConnectProvider.php
@@ -90,9 +90,10 @@ final class OpenIdConnectProvider extends AbstractProvider
         if (!isset($this->options['jwtCookieName'])) {
             $this->options['jwtCookieName'] = 'flownative_oidc_jwt';
         }
+
         try {
             $jwks = (new OpenIdConnectClient($this->options['serviceName']))->getJwks();
-            $identityToken = $authenticationToken->extractIdentityTokenFromRequest($this->options['jwtCookieName']);
+            list($identityToken, $accessToken) = $authenticationToken->extractTokensFromRequest($this->options['jwtCookieName']);
 
             try {
                 $hasValidSignature = $identityToken->hasValidSignature($jwks);
@@ -137,7 +138,7 @@ final class OpenIdConnectProvider extends AbstractProvider
 
         $this->logger->debug(sprintf('OpenID Connect: Successfully authenticated account "%s" with authentication provider %s. Roles: %s', $account->getAccountIdentifier(), $account->getAuthenticationProviderName(), implode(', ', $this->getConfiguredRoles($identityToken))), LogEnvironment::fromMethodName(__METHOD__));
 
-        $this->emitAuthenticated($authenticationToken, $identityToken, $this->policyService->getRoles());
+        $this->emitAuthenticated($authenticationToken, $identityToken, $accessToken, $this->policyService->getRoles());
     }
 
     /**
@@ -155,7 +156,7 @@ final class OpenIdConnectProvider extends AbstractProvider
      * @return void
      * @Flow\Signal()
      */
-    public function emitAuthenticated(TokenInterface $authenticationToken, IdentityToken $identityToken, array $roles): void
+    public function emitAuthenticated(TokenInterface $authenticationToken, IdentityToken $identityToken, string $accessToken, array $roles): void
     {
     }
 

--- a/Classes/OpenIdConnectClient.php
+++ b/Classes/OpenIdConnectClient.php
@@ -242,11 +242,13 @@ final class OpenIdConnectClient
         if (!$authorization instanceof Authorization) {
             throw new ServiceException(sprintf('OpenID Connect Client: Authorization %s was not found', $authorizationIdentifier), 1567853403);
         }
+
         $accessToken = $authorization->getAccessToken();
         if (!$accessToken) {
             throw new ServiceException(sprintf('OpenID Connect Client: Authorization %s contained no access token', $authorizationIdentifier), 1567853441);
         }
         $tokenValues = $accessToken->getValues();
+
         if (!isset($tokenValues['id_token'])) {
             throw new ServiceException('OpenID Connect Client: No id_token found in values of current oAuth token', 1559208674);
         }
@@ -335,7 +337,7 @@ final class OpenIdConnectClient
      * @return Authorization|null
      * @throws ConnectionException
      */
-    private function getAuthorization(string $authorizationIdentifier): ?Authorization
+    public function getAuthorization(string $authorizationIdentifier): ?Authorization
     {
         try {
             $authorization = $this->oAuthClient->getAuthorization($authorizationIdentifier);


### PR DESCRIPTION
to the authenticated signal.

This is a super hacky way. The access token is not saved in the cookie and can only be accessed during the authentication request.