### PR TITLE
Change log severity for existing token message to "debug"

### DIFF
--- a/Classes/OpenIdConnectClient.php
+++ b/Classes/OpenIdConnectClient.php
@@ -197,7 +197,7 @@ final class OpenIdConnectClient
 
         } else {
             $expiresInSeconds = $accessToken->getExpires() - time();
-            $this->logger->info(sprintf('OpenID Connect Client: Using existing access token for service %s using client id %s %s. Remaining lifetime: %d seconds', $serviceName, $clientId, ($scope ? 'with scope "' . $scope . '"' : 'without a scope'), $expiresInSeconds), LogEnvironment::fromMethodName(__METHOD__));
+            $this->logger->debug(sprintf('OpenID Connect Client: Using existing access token for service %s using client id %s %s. Remaining lifetime: %d seconds', $serviceName, $clientId, ($scope ? 'with scope "' . $scope . '"' : 'without a scope'), $expiresInSeconds), LogEnvironment::fromMethodName(__METHOD__));
         }
 
         return $accessToken;


### PR DESCRIPTION
The message "OpenID Connect Client: Using existing access token for service %s using client id %s %s. Remaining lifetime: %d seconds" can appear very often in production. It is, however, rarely useful, unless you are debugging. Therefore lowered the severity to "debug" for this message.