### PR TITLE
Try to refresh an expired identity token

### DIFF
--- a/Classes/Authentication/OpenIdConnectToken.php
+++ b/Classes/Authentication/OpenIdConnectToken.php
@@ -28,6 +28,8 @@ final class OpenIdConnectToken extends AbstractToken implements SessionlessToken
 
     protected string $authorizationHeader = '';
 
+    protected string $refreshToken = '';
+
     /**
      * @throws InvalidAuthenticationStatusException
      */
@@ -74,7 +76,9 @@ final class OpenIdConnectToken extends AbstractToken implements SessionlessToken
             $client = new OpenIdConnectClient($tokenArguments[TokenArguments::SERVICE_NAME]);
 
             try {
-                $identityToken = $client->getIdentityToken($authorizationIdentifier);
+                $tokenSet = $client->getIdentityToken($authorizationIdentifier);
+                $identityToken = $tokenSet->identityToken;
+                $this->refreshToken = $tokenSet->refreshToken;
                 $client->removeAuthorization($authorizationIdentifier);
             } catch (ServiceException | ConnectionException $exception) {
                 throw new AccessDeniedException(sprintf('Could not extract identity token for authorization identifier "%s": %s', $authorizationIdentifier, $exception->getMessage()), 1560350413, $exception);
@@ -85,6 +89,11 @@ final class OpenIdConnectToken extends AbstractToken implements SessionlessToken
 
         // NOTE: This token is not verified yet – signature and expiration time must be checked by code using this token
         return $identityToken;
+    }
+
+    public function getRefreshToken(): string
+    {
+        return $this->refreshToken;
     }
 
     /**

--- a/Classes/TokenSet.php
+++ b/Classes/TokenSet.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Flownative\OpenIdConnect\Client;
+
+final class TokenSet
+{
+    public function __construct(
+        public readonly IdentityToken $identityToken,
+        public readonly string $refreshToken,
+    )
+    {
+    }
+}


### PR DESCRIPTION
When the identity token expires, so far the user needed to do an (interactive) login with their IDP. This is inconvenient and causes issues with background requests in Neos, making them fail.

This change stores a refresh token in the user session, so as long as the user does not log out from Neos, an expired identity token will be refreshed if possible.

Fixes #15