### PR TITLE
Make the offline_access scope of the entry point optional

### DIFF
--- a/Classes/Authentication/OpenIdConnectEntryPoint.php
+++ b/Classes/Authentication/OpenIdConnectEntryPoint.php
@@ -36,7 +36,7 @@ final class OpenIdConnectEntryPoint extends AbstractEntryPoint
 
         $client = new OpenIdConnectClient($this->options['serviceName']);
         try {
-            $providerUri = $client->startAuthorization($request->getUri(), $this->options['scope'] ?? '');
+            $providerUri = $client->startAuthorization($request->getUri(), $this->options['scope'] ?? '', $this->options['requestRefreshToken'] ?? true);
         } catch (OAuthClientException | ServiceException $exception) {
             $this->logger->error(sprintf('OpenID Connect: Authentication for service "%s" failed: %s', $this->options['serviceName'], $exception->getMessage()), LogEnvironment::fromMethodName(__METHOD__));
             return $response;
@@ -58,6 +58,9 @@ final class OpenIdConnectEntryPoint extends AbstractEntryPoint
         }
         if (isset($this->options['scope']) && !is_string($this->options['scope'])) {
             throw new ConfigurationException('OpenID Connect: "scope" option was not configured correctly for OpenIdConnectEntryPoint', 1560259102);
+        }
+        if (isset($this->options['requestRefreshToken']) && !is_bool($this->options['requestRefreshToken'])) {
+            throw new ConfigurationException('OpenID Connect: "requestRefreshToken" option must be a boolean for OpenIdConnectEntryPoint', 1789108753);
         }
     }
 

--- a/Classes/OpenIdConnectClient.php
+++ b/Classes/OpenIdConnectClient.php
@@ -208,21 +208,21 @@ final class OpenIdConnectClient
      * This method is an interactive authorization, which usually requires a browser to work.
      *
      * @param string $scope The authorization scope. Must be identifiers separated by space. "openid" will automatically be requested
+     * @param bool $requestRefreshToken If "offline_access" should be requested, so that an expired identity token can be refreshed
      * @throws OAuthClientException
      */
-    public function startAuthorization(UriInterface $returnToUri, string $scope): UriInterface
+    public function startAuthorization(UriInterface $returnToUri, string $scope, bool $requestRefreshToken = true): UriInterface
     {
         $returnArguments = (string)TokenArguments::fromArray([TokenArguments::SERVICE_NAME => $this->serviceName]);
         if (str_starts_with($returnArguments, 'ERROR')) {
             throw new \RuntimeException(substr($returnArguments, 6));
         }
         $returnToUri = $returnToUri->withQuery(trim($returnToUri->getQuery() . '&' . OpenIdConnectToken::OIDC_PARAMETER_NAME . '=' . urlencode($returnArguments), '&'));
-        $scope = trim(implode(' ', array_unique(array_merge(explode(' ', $scope), ['openid']))));
 
         if (empty($this->options['clientId']) || empty($this->options['clientSecret'])) {
             throw new \RuntimeException(sprintf('OpenID Connect Client: Authorization Code Flow requires "clientId" and "clientSecret" to be configured for service "%s".', $this->serviceName), 1596456168);
         }
-        return $this->oAuthClient->startAuthorization($this->options['clientId'], $this->options['clientSecret'], $returnToUri, $scope);
+        return $this->oAuthClient->startAuthorization($this->options['clientId'], $this->options['clientSecret'], $returnToUri, $this->buildAuthorizationScope($scope, $requestRefreshToken));
     }
 
     /**
@@ -378,5 +378,11 @@ final class OpenIdConnectClient
             throw new ConnectionException(sprintf('OpenID Connect Client: Failed retrieving oAuth token %s: %s', $authorizationIdentifier, $exception->getMessage()), 1559202394);
         }
         return $authorization;
+    }
+
+    private function buildAuthorizationScope(string $scope, bool $requestRefreshToken): string
+    {
+        $requiredScopeIdentifiers = $requestRefreshToken ? ['openid', 'offline_access'] : ['openid'];
+        return trim(implode(' ', array_unique(array_merge(explode(' ', $scope), $requiredScopeIdentifiers))));
     }
 }

--- a/Classes/OpenIdConnectClient.php
+++ b/Classes/OpenIdConnectClient.php
@@ -217,7 +217,7 @@ final class OpenIdConnectClient
             throw new \RuntimeException(substr($returnArguments, 6));
         }
         $returnToUri = $returnToUri->withQuery(trim($returnToUri->getQuery() . '&' . OpenIdConnectToken::OIDC_PARAMETER_NAME . '=' . urlencode($returnArguments), '&'));
-        $scope = trim(implode(' ', array_unique(array_merge(explode(' ', $scope), ['openid', 'offline_access']))));
+        $scope = trim(implode(' ', array_unique(array_merge(explode(' ', $scope), ['openid']))));
 
         if (empty($this->options['clientId']) || empty($this->options['clientSecret'])) {
             throw new \RuntimeException(sprintf('OpenID Connect Client: Authorization Code Flow requires "clientId" and "clientSecret" to be configured for service "%s".', $this->serviceName), 1596456168);

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Neos:
             entryPoint: 'Flownative\OpenIdConnect\Client\Authentication\OpenIdConnectEntryPoint'
             entryPointOptions:
               serviceName: 'test'
-              scopes: ['sub', 'profile', 'name']
+              scope: 'profile name'
 
         authenticationStrategy: atLeastOneToken
 
@@ -296,6 +296,27 @@ Neos:
 Without further programming you need to manually create a Neos user
 which has the same username as the one provided in the "sub" claim by
 the OIDC identity provider.
+
+### Refreshing expired identity tokens
+
+The entry point requests the scope "offline_access" in addition to
+"openid" and the configured scope. With this scope, identity providers
+like Auth0 or Microsoft Entra ID issue a refresh token. The refresh
+token is stored in the user's session and is used to refresh an
+expired identity token without an interactive login.
+
+Some identity providers treat this scope differently. Google rejects
+it with an "invalid_scope" error. Keycloak issues an offline token
+which does not expire with the SSO session. If you don't need refresh
+tokens, or your identity provider does not support the scope, disable
+it in the entry point options:
+
+```yaml
+            entryPointOptions:
+              serviceName: 'test'
+              scope: 'profile name'
+              requestRefreshToken: false
+```
 
 Note: Check the [Flownative.OpenidConnect.Neos](https://github.com/flownative/openidconnect-neos) package for a working implementation.
 

--- a/Tests/Unit/OpenIdConnectClientTest.php
+++ b/Tests/Unit/OpenIdConnectClientTest.php
@@ -200,6 +200,31 @@ class OpenIdConnectClientTest extends TestCase
         static::assertSame($expectedAccessToken->getExpires(), $actualAccessToken->getExpires());
     }
 
+    public static function authorizationScopes(): array
+    {
+        return [
+            'empty scope with refresh token' => ['', true, 'openid offline_access'],
+            'empty scope without refresh token' => ['', false, 'openid'],
+            'custom scope with refresh token' => ['profile email', true, 'profile email openid offline_access'],
+            'custom scope without refresh token' => ['profile email', false, 'profile email openid'],
+            'duplicate identifiers are removed' => ['openid offline_access', true, 'openid offline_access'],
+            'explicit offline_access is kept' => ['profile offline_access', false, 'profile offline_access openid'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider authorizationScopes
+     * @throws
+     */
+    public function buildAuthorizationScopeAddsRequiredScopeIdentifiers(string $scope, bool $requestRefreshToken, string $expectedScope): void
+    {
+        $method = new \ReflectionMethod(OpenIdConnectClient::class, 'buildAuthorizationScope');
+        $method->setAccessible(true);
+
+        static::assertSame($expectedScope, $method->invoke($this->oidcClient, $scope, $requestRefreshToken));
+    }
+
     /**
      * Injects $dependency into property $name of $target
      *


### PR DESCRIPTION
The entry point requests the `offline_access` scope by default, so that an expired identity token can be refreshed. The new entry point option `requestRefreshToken: false` turns this off.

Identity providers handle this scope differently. Auth0 and Microsoft Entra ID need it to issue a refresh token. Google rejects it with an `invalid_scope` error. Keycloak issues an offline token which does not expire with the SSO session. The default stays, so installations which rely on token refresh keep working.

Also fixes the README example, which used a `scopes` option the entry point does not read.