### PR TITLE
Declare the service name of oidc:discover as explicitly nullable

### DIFF
--- a/Classes/Command/OidcCommandController.php
+++ b/Classes/Command/OidcCommandController.php
@@ -41,7 +41,7 @@ final class OidcCommandController extends CommandController
      * @param string|null $serviceName The service name, as it was configured via Flow settings
      * @return void
      */
-    public function discoverCommand(string $serviceName = null): void
+    public function discoverCommand(?string $serviceName = null): void
     {
         if (empty($this->settings['services'])) {
             $this->outputLine('<error>There are no services configured in the Flow settings</error>');


### PR DESCRIPTION
The optional `$serviceName` parameter of `OidcCommandController::discoverCommand()` is now declared as `?string`.

With PHP 8.4, `string $serviceName = null` triggers "Implicitly marking parameter $serviceName as nullable is deprecated". Flow reflects all command controllers, for example when rendering `./flow help`, so the notice showed up in every installation running PHP 8.4 or later and was reported by error trackers. This was the only implicitly nullable parameter in the package; linting all classes with PHP 8.4 reports no further deprecations.

`?string` is supported by all PHP versions the package allows, so the change is backwards compatible.
